### PR TITLE
Add builtin rule for wodeshucheng

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chinese-conv": "^3.2.2"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.2",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitejs/plugin-vue": "^5.2.0",
@@ -237,7 +238,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -281,7 +281,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -881,9 +880,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1436,7 +1435,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1934,7 +1932,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2483,7 +2480,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2544,7 +2540,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2650,6 +2645,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
@@ -3966,7 +3974,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4069,7 +4076,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4691,7 +4697,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4723,7 +4728,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4832,7 +4836,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -4906,7 +4909,6 @@
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chinese-conv": "^3.2.2"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.2",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitejs/plugin-vue": "^5.2.0",

--- a/scripts/MyNovelReader.user.js
+++ b/scripts/MyNovelReader.user.js
@@ -1067,6 +1067,7 @@ var MyNovelReader = (function(exports) {
     ".chapter-title",
     ".chapter_title",
     ".bookname h1",
+    "h1.title",
     ".title h1",
     "#chapter_title",
     ".readtitle h1",
@@ -1080,6 +1081,7 @@ var MyNovelReader = (function(exports) {
     "#bookname",
     ".novel-title",
     "h2.title",
+    ".layout-tit a[title]",
     ".breadcrumb a:last-of-type",
     ".chapter-nav a:last-of-type"
   ];
@@ -2118,6 +2120,46 @@ var MyNovelReader = (function(exports) {
     }
   ];
   const simplifiedRules = [
+    // 我的书城网（章节正文存在混入的转义标签和反爬噪声）
+    {
+      id: "wodeshucheng",
+      name: "我的书城网",
+      version: 1,
+      match: {
+        pattern: "^https?://www\\.wodeshucheng\\.net/.*?\\.html$"
+      },
+      content: {
+        selector: "#content",
+        replace: [
+          // 清除正文内被转义的段落、换行标签
+          { pattern: "&lt;/?p&gt;", replacement: "", flags: "gi" },
+          { pattern: "&lt;br\\s*/?&gt;", replacement: "", flags: "gi" },
+          // 去掉夹杂的反爬噪声（包含反斜杠的乱码片段）
+          { pattern: "\\\\[^\\s<]{2,}", replacement: "", flags: "g" },
+          // 清理尾部插入的脚本标记或碎片
+          { pattern: "chapter_\\(\\);?", replacement: "", flags: "gi" },
+          { pattern: "script\\/script", replacement: "", flags: "gi" },
+          // 移除以“#?”开头的乱码提示
+          { pattern: "#\\?[^<\\n]{0,80}", replacement: "", flags: "g" }
+        ]
+      },
+      navigation: {
+        prev: "#prev_url",
+        index: "#info_url",
+        next: "#next_url"
+      },
+      title: {
+        selector: "h1.title",
+        bookSelector: ".layout-tit a[title]"
+      },
+      advanced: {
+        checkSection: true
+      },
+      meta: {
+        source: "builtin",
+        exampleUrl: "https://www.wodeshucheng.net/book_95122894/455913227.html"
+      }
+    },
     // 零点看书 / 文库吧系（示例：23.225.121.247/ldks/111291/42509753_2.html）
     // 特点：
     // - 同一章分页：/42509753.html -> /42509753_2.html（下一页），最后一页才出现“下一章”

--- a/src/core/detection/TitleDetector.ts
+++ b/src/core/detection/TitleDetector.ts
@@ -12,6 +12,7 @@ const KNOWN_TITLE_SELECTORS = [
   '.chapter-title',
   '.chapter_title',
   '.bookname h1',
+  'h1.title',
   '.title h1',
   '#chapter_title',
   '.readtitle h1',
@@ -27,6 +28,7 @@ const KNOWN_BOOK_TITLE_SELECTORS = [
   '#bookname',
   '.novel-title',
   'h2.title',
+  '.layout-tit a[title]',
   '.breadcrumb a:last-of-type',
   '.chapter-nav a:last-of-type',
 ];

--- a/src/core/rules/builtInRules.ts
+++ b/src/core/rules/builtInRules.ts
@@ -401,6 +401,47 @@ const specialRules: SiteRule[] = [
  * These can't be auto-detected but don't need iframe/mutations
  */
 const simplifiedRules: SiteRule[] = [
+  // 我的书城网（章节正文存在混入的转义标签和反爬噪声）
+  {
+    id: 'wodeshucheng',
+    name: '我的书城网',
+    version: 1,
+    match: {
+      pattern: '^https?://www\\.wodeshucheng\\.net/.*?\\.html$',
+    },
+    content: {
+      selector: '#content',
+      replace: [
+        // 清除正文内被转义的段落、换行标签
+        { pattern: '&lt;/?p&gt;', replacement: '', flags: 'gi' },
+        { pattern: '&lt;br\\s*/?&gt;', replacement: '', flags: 'gi' },
+        // 去掉夹杂的反爬噪声（包含反斜杠的乱码片段）
+        { pattern: '\\\\[^\\s<]{2,}', replacement: '', flags: 'g' },
+        // 清理尾部插入的脚本标记或碎片
+        { pattern: 'chapter_\\(\\);?', replacement: '', flags: 'gi' },
+        { pattern: 'script\\/script', replacement: '', flags: 'gi' },
+        // 移除以“#?”开头的乱码提示
+        { pattern: '#\\?[^<\\n]{0,80}', replacement: '', flags: 'g' },
+      ],
+    },
+    navigation: {
+      prev: '#prev_url',
+      index: '#info_url',
+      next: '#next_url',
+    },
+    title: {
+      selector: 'h1.title',
+      bookSelector: '.layout-tit a[title]',
+    },
+    advanced: {
+      checkSection: true,
+    },
+    meta: {
+      source: 'builtin',
+      exampleUrl: 'https://www.wodeshucheng.net/book_95122894/455913227.html',
+    },
+  },
+
   // 零点看书 / 文库吧系（示例：23.225.121.247/ldks/111291/42509753_2.html）
   // 特点：
   // - 同一章分页：/42509753.html -> /42509753_2.html（下一页），最后一页才出现“下一章”


### PR DESCRIPTION
## Summary
- add a builtin rule for wodeshucheng to target the correct content, navigation, and pagination while stripping obfuscated noise
- expand known chapter and book title selectors to capture site-specific headings
- add @eslint/js as a dev dependency so eslint runs successfully in this project

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ad4b3478832f806c1c544b0a306b)