### PR TITLE
Include `chapters` and `/novel/chapters` in chapter URL detection

### DIFF
--- a/scripts/MyNovelReader.user.js
+++ b/scripts/MyNovelReader.user.js
@@ -7229,7 +7229,7 @@ findNextChapterUrl(doc2, currentUrl) {
   const TOC_TITLE_PATTERN = /(?:章节目录|章節目錄|章节列表|章節列表|目录|目錄|书目|書目|toc|catalog|contents?)/i;
   const TOC_URL_PATTERN = /(?:^|\/)(?:catalog|toc|contents?|mulu|dir(?:ectory)?|chapterlist|chapters)(?:\/|$)/i;
   const TOC_QUERY_PATTERN = /[?&](?:catalog|toc|contents?)=|[?&](?:mulu|dir)=/i;
-  const CHAPTER_URL_STRONG_PATTERN = /\/(?:chapter|read|txt|article)\/[^?#]*\d/i;
+  const CHAPTER_URL_STRONG_PATTERN = /\/(?:chapter|chapters?|read|txt|article|novel\/chapters)\/[^?#]*\d/i;
   const CHAPTER_LINK_TEXT_PATTERN = /第\s*[一二两三四五六七八九十○零百千万亿0-9]{1,9}\s*[章回卷节折篇幕集话話]|Chapter\s*\d+/i;
   const NAV_LINK_TEXT_PATTERN = /(?:下一[章页]|上一[章页]|下一章|上一章|next|prev)/i;
   function parseHttpUrl(url) {
@@ -7535,7 +7535,7 @@ async manualEnable(doc2 = document) {
     return managerInstance;
   }
   const VERSION = "9.0.0";
-  const BUILD_DATE = "2026-01-04";
+  const BUILD_DATE = "2026-01-05";
   /**
   * @vue/shared v3.5.25
   * (c) 2018-present Yuxi (Evan) You and Vue contributors

--- a/src/core/auto-enable/PageKind.ts
+++ b/src/core/auto-enable/PageKind.ts
@@ -9,8 +9,9 @@ const TOC_URL_PATTERN =
 const TOC_QUERY_PATTERN = /[?&](?:catalog|toc|contents?)=|[?&](?:mulu|dir)=/i;
 
 // URL-only chapter detection should be conservative to avoid triggering on book/detail/list pages.
+// Keep numeric requirements and only add explicit chapter-style segments (e.g. chapters, /novel/chapters/).
 // For ambiguous URLs (e.g. numeric .html), fall back to DOM heuristics instead.
-const CHAPTER_URL_STRONG_PATTERN = /\/(?:chapter|read|txt|article)\/[^?#]*\d/i;
+const CHAPTER_URL_STRONG_PATTERN = /\/(?:chapter|chapters?|read|txt|article|novel\/chapters)\/[^?#]*\d/i;
 
 const CHAPTER_LINK_TEXT_PATTERN =
   /第\s*[一二两三四五六七八九十○零百千万亿0-9]{1,9}\s*[章回卷节折篇幕集话話]|Chapter\s*\d+/i;


### PR DESCRIPTION
### Motivation
- Recognize chapter pages whose paths use `chapters` or `/novel/chapters` (for example `https://ttks.tw/novel/chapters/.../1313.html`) that were not matched before.
- Maintain conservative URL-only detection by keeping a numeric gating requirement to avoid misclassifying book/list/detail pages.
- Update the in-file comment to reflect the addition of explicit chapter-style segments to URL detection.

### Description
- Update `CHAPTER_URL_STRONG_PATTERN` in `src/core/auto-enable/PageKind.ts` to `/\/(?:chapter|chapters?|read|txt|article|novel\/chapters)\/[^?#]*\d/i` to include `chapters` and `novel/chapters` variants.
- Adjust the surrounding comment to note that explicit chapter-style segments were added while preserving the numeric requirement.
- The change is limited to `src/core/auto-enable/PageKind.ts` with no other behavioral modifications.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b4a0fdcc4832f9bcff6d1d407d1bd)