### PR TITLE
Improve quickCheck chapter heuristics

### DIFF
--- a/scripts/MyNovelReader.user.js
+++ b/scripts/MyNovelReader.user.js
@@ -3030,6 +3030,7 @@ detectSection(doc2 = document, currentUrl = window.location.href) {
       return this.navigationDetector.detectSection(doc2, currentUrl, navigation);
     }
 quickCheck(doc2 = document) {
+      const currentUrl = window.location.href;
       const indicators = [
 () => {
           const title = doc2.title;
@@ -3041,12 +3042,17 @@ quickCheck(doc2 = document) {
         },
 () => {
           const links = Array.from(doc2.querySelectorAll("a"));
-          return links.some((a) => /下一[章页]/.test(a.textContent || ""));
+          return links.some((a) => /下一[章页节篇回]|下页/i.test(a.textContent || ""));
         },
 () => {
           const body = doc2.body;
           const text2 = (body == null ? void 0 : body.textContent) || "";
           return text2.length > 3e3;
+        },
+() => {
+          const body = doc2.body;
+          const text2 = (body == null ? void 0 : body.textContent) || "";
+          return /\/chapters?\//i.test(currentUrl) && text2.length > 1200;
         }
       ];
       const matches = indicators.filter((check) => {
@@ -7535,7 +7541,7 @@ async manualEnable(doc2 = document) {
     return managerInstance;
   }
   const VERSION = "9.0.0";
-  const BUILD_DATE = "2026-01-04";
+  const BUILD_DATE = "2026-01-05";
   /**
   * @vue/shared v3.5.25
   * (c) 2018-present Yuxi (Evan) You and Vue contributors

--- a/src/core/detection/index.ts
+++ b/src/core/detection/index.ts
@@ -72,6 +72,7 @@ export class DetectionEngine {
    * Quick check if page looks like a novel chapter
    */
   quickCheck(doc: Document = document): boolean {
+    const currentUrl = window.location.href;
     // Check for common novel page indicators
     const indicators = [
       // Check document title
@@ -87,13 +88,19 @@ export class DetectionEngine {
       // Check for navigation links
       () => {
         const links = Array.from(doc.querySelectorAll('a'));
-        return links.some(a => /下一[章页]/.test(a.textContent || ''));
+        return links.some(a => /下一[章页节篇回]|下页/i.test(a.textContent || ''));
       },
       // Check text content length
       () => {
         const body = doc.body;
         const text = body?.textContent || '';
         return text.length > 3000;
+      },
+      // Check URL and content length for chapter-like paths
+      () => {
+        const body = doc.body;
+        const text = body?.textContent || '';
+        return /\/chapters?\//i.test(currentUrl) && text.length > 1200;
       },
     ];
 


### PR DESCRIPTION
### Motivation
- Make `quickCheck` less likely to reject genuine chapter pages when the URL contains an obvious chapter path.
- Broaden detection of navigation links so common labels like “下一节” and “下页” are recognized as chapter navigation.
- Provide a lower content-length threshold for pages served under chapter-like paths to reduce false negatives.

### Description
- Read `window.location.href` inside `quickCheck` and add a URL-based indicator that matches `/chapters?/` and requires text length > 1200.
- Expand the navigation link regular expression to match additional common labels (`下一[章页节篇回]|下页`) so more “next chapter” links are detected.
- Leave the existing indicators and the requirement of at least two matching indicators unchanged to preserve overall sensitivity.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b4a116e2c832fb40403db545b607c)