### PR TITLE
Detect Cloudflare challenge pages and defer protections/auto-enable

### DIFF
--- a/scripts/MyNovelReader.user.js
+++ b/scripts/MyNovelReader.user.js
@@ -6302,6 +6302,21 @@ smartSelect(doc2, selector) {
     }
     return parserInstance;
   }
+  const isCloudflareChallenge = (doc2 = document) => {
+    var _a;
+    const pathname = ((_a = doc2.location) == null ? void 0 : _a.pathname) || window.location.pathname;
+    if (pathname.startsWith("/cdn-cgi/")) return true;
+    const selectors = [
+      '[id*="cf-chl"]',
+      '[class*="cf-chl"]',
+      '[id*="challenge"]',
+      '[class*="challenge"]',
+      'form[action*="/cdn-cgi/"]',
+      'iframe[src*="challenges.cloudflare.com"]',
+      'iframe[src*="captcha.cloudflare.com"]'
+    ];
+    return doc2.querySelector(selectors.join(",")) !== null;
+  };
   const DEFAULT_OPTIONS$1 = {
     blockRedirects: true,
     enableRightClick: true,
@@ -6329,34 +6344,41 @@ activate(options) {
         this.deactivate();
       }
       this.isActive = true;
-      if (this.options.clearTimers) {
+      const isChallenge = isCloudflareChallenge();
+      const effectiveOptions = isChallenge ? {
+        ...this.options,
+        blockRedirects: false,
+        clearTimers: false,
+        removeEventHijacking: false
+      } : this.options;
+      if (effectiveOptions.clearTimers) {
         this.clearTimers();
       }
-      if (this.options.blockRedirects) {
+      if (effectiveOptions.blockRedirects) {
         this.blockRedirects();
       }
-      if (this.options.enableRightClick) {
+      if (effectiveOptions.enableRightClick) {
         this.enableRightClick();
       }
-      if (this.options.enableSelection) {
+      if (effectiveOptions.enableSelection) {
         this.enableSelection();
       }
-      if (this.options.enableCopy) {
+      if (effectiveOptions.enableCopy) {
         this.enableCopy();
       }
-      if (this.options.unlockKeyboard) {
+      if (effectiveOptions.unlockKeyboard) {
         this.unlockKeyboard();
       }
-      if (this.options.blockPopups) {
+      if (effectiveOptions.blockPopups) {
         this.blockPopups();
       }
-      if (this.options.cleanupScripts) {
+      if (effectiveOptions.cleanupScripts) {
         this.cleanupScripts();
       }
-      if (this.options.removeEventHijacking) {
+      if (effectiveOptions.removeEventHijacking) {
         this.removeEventHijacking();
       }
-      if (this.options.blockVisibilityDetection) {
+      if (effectiveOptions.blockVisibilityDetection) {
         this.blockVisibilityDetection();
       }
     }
@@ -7343,6 +7365,14 @@ async check(doc2 = document) {
       var _a, _b, _c, _d;
       const url = ((_a = doc2.location) == null ? void 0 : _a.href) || window.location.href;
       const decide = (decision2) => this.recordDecision(url, decision2);
+      if (isCloudflareChallenge(doc2)) {
+        return decide({
+          shouldEnable: false,
+          method: "manual",
+          confidence: 0,
+          reasons: ["Cloudflare Challenge 页面，等待验证完成"]
+        });
+      }
       if (this.shouldSkip(url)) {
         return decide({
           shouldEnable: false,
@@ -7535,7 +7565,7 @@ async manualEnable(doc2 = document) {
     return managerInstance;
   }
   const VERSION = "9.0.0";
-  const BUILD_DATE = "2026-01-04";
+  const BUILD_DATE = "2026-01-05";
   /**
   * @vue/shared v3.5.25
   * (c) 2018-present Yuxi (Evan) You and Vue contributors

--- a/src/core/AutoEnableManager.ts
+++ b/src/core/AutoEnableManager.ts
@@ -9,7 +9,7 @@
  */
 
 import { DetectionEngine, type DetectionEngineResult } from '@/core/detection';
-import { getSiteProtection, type ProtectionOptions } from '@/core/protection';
+import { getSiteProtection, isCloudflareChallenge, type ProtectionOptions } from '@/core/protection';
 import { type ParsedChapter, Parser } from '@/core/parser';
 import { createRuleSaver } from '@/core/auto-enable/RuleSaver';
 import { createSectionMerger } from '@/core/auto-enable/SectionMerger';
@@ -145,6 +145,15 @@ export class AutoEnableManager {
     const url = doc.location?.href || window.location.href;
     const decide = (decision: AutoEnableDecision): AutoEnableDecision =>
       this.recordDecision(url, decision);
+
+    if (isCloudflareChallenge(doc)) {
+      return decide({
+        shouldEnable: false,
+        method: 'manual',
+        confidence: 0,
+        reasons: ['Cloudflare Challenge 页面，等待验证完成'],
+      });
+    }
 
     // Check skip patterns
     if (this.shouldSkip(url)) {

--- a/src/core/protection/SiteProtection.ts
+++ b/src/core/protection/SiteProtection.ts
@@ -33,6 +33,23 @@ export interface ProtectionOptions {
   cleanupScripts?: boolean;
 }
 
+export const isCloudflareChallenge = (doc: Document = document): boolean => {
+  const pathname = doc.location?.pathname || window.location.pathname;
+  if (pathname.startsWith('/cdn-cgi/')) return true;
+
+  const selectors = [
+    '[id*="cf-chl"]',
+    '[class*="cf-chl"]',
+    '[id*="challenge"]',
+    '[class*="challenge"]',
+    'form[action*="/cdn-cgi/"]',
+    'iframe[src*="challenges.cloudflare.com"]',
+    'iframe[src*="captcha.cloudflare.com"]',
+  ];
+
+  return doc.querySelector(selectors.join(',')) !== null;
+};
+
 const DEFAULT_OPTIONS: ProtectionOptions = {
   blockRedirects: true,
   enableRightClick: true,
@@ -72,44 +89,54 @@ export class SiteProtection {
     }
     this.isActive = true;
 
+    const isChallenge = isCloudflareChallenge();
+    const effectiveOptions = isChallenge
+      ? {
+          ...this.options,
+          blockRedirects: false,
+          clearTimers: false,
+          removeEventHijacking: false,
+        }
+      : this.options;
+
     // Clear timers first to reduce CPU usage from tracking scripts
-    if (this.options.clearTimers) {
+    if (effectiveOptions.clearTimers) {
       this.clearTimers();
     }
 
-    if (this.options.blockRedirects) {
+    if (effectiveOptions.blockRedirects) {
       this.blockRedirects();
     }
 
-    if (this.options.enableRightClick) {
+    if (effectiveOptions.enableRightClick) {
       this.enableRightClick();
     }
 
-    if (this.options.enableSelection) {
+    if (effectiveOptions.enableSelection) {
       this.enableSelection();
     }
 
-    if (this.options.enableCopy) {
+    if (effectiveOptions.enableCopy) {
       this.enableCopy();
     }
 
-    if (this.options.unlockKeyboard) {
+    if (effectiveOptions.unlockKeyboard) {
       this.unlockKeyboard();
     }
 
-    if (this.options.blockPopups) {
+    if (effectiveOptions.blockPopups) {
       this.blockPopups();
     }
 
-    if (this.options.cleanupScripts) {
+    if (effectiveOptions.cleanupScripts) {
       this.cleanupScripts();
     }
 
-    if (this.options.removeEventHijacking) {
+    if (effectiveOptions.removeEventHijacking) {
       this.removeEventHijacking();
     }
 
-    if (this.options.blockVisibilityDetection) {
+    if (effectiveOptions.blockVisibilityDetection) {
       this.blockVisibilityDetection();
     }
   }

--- a/src/core/protection/index.ts
+++ b/src/core/protection/index.ts
@@ -2,5 +2,5 @@
  * Protection module exports
  */
 
-export { SiteProtection, getSiteProtection } from './SiteProtection';
+export { SiteProtection, getSiteProtection, isCloudflareChallenge } from './SiteProtection';
 export type { ProtectionOptions } from './SiteProtection';

--- a/tests/unit/autoEnableManager.test.ts
+++ b/tests/unit/autoEnableManager.test.ts
@@ -67,6 +67,7 @@ vi.mock('@/core/rules/RuleManager', () => ({
 
 vi.mock('@/core/protection', () => ({
   getSiteProtection: () => mockedProtection,
+  isCloudflareChallenge: vi.fn(() => false),
 }));
 
 vi.mock('@/core/auto-enable/SectionMerger', () => ({


### PR DESCRIPTION
### Motivation
- Avoid interfering with Cloudflare challenge/captcha pages where aggressive protections (redirect blocking, timer clearing, event hijack removal) can break verification flows.
- Prevent the auto-enable flow from forcing the reader UI during challenge pages to avoid user confusion and verification loops.
- Ensure site protection features are conservative on verification pages so the browser can complete challenge flows normally.

### Description
- Add exported helper `isCloudflareChallenge(doc)` in `src/core/protection/SiteProtection.ts` to detect Cloudflare challenge pages via path and DOM markers.
- Update `SiteProtection.activate()` to compute `effectiveOptions` and temporarily disable `blockRedirects`, `clearTimers`, and `removeEventHijacking` when a challenge is detected.
- Update `AutoEnableManager.check()` in `src/core/AutoEnableManager.ts` to early-return a manual decision when `isCloudflareChallenge(doc)` is true to skip auto-enable.
- Adjust imports and wiring to use the new `isCloudflareChallenge` helper in the auto-enable flow.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b4a120f28832fb6a6c9fe26b0a8a2)